### PR TITLE
release: 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [1.4.0](https://github.com/flex-development/errnode/compare/1.3.0...1.4.0) (2023-01-23)
+
+
+### :package: Build
+
+* **deps-dev:** Bump @commitlint/cli from 17.4.0 to 17.4.2 ([#28](https://github.com/flex-development/errnode/issues/28)) ([08ab50e](https://github.com/flex-development/errnode/commit/08ab50eb8f5dceee629b8e64a00795d4fa59e3d0))
+* **deps-dev:** Bump @types/fs-extra from 11.0.0 to 11.0.1 ([#26](https://github.com/flex-development/errnode/issues/26)) ([9f378a5](https://github.com/flex-development/errnode/commit/9f378a5d401d56e60221f9d6444e42275bdb4473))
+* **deps-dev:** Bump @typescript-eslint/eslint-plugin from 5.48.0 to 5.48.1 ([#23](https://github.com/flex-development/errnode/issues/23)) ([0dbfffa](https://github.com/flex-development/errnode/commit/0dbfffa8b609e08a6e74d90daa28157c374f3485))
+* **deps-dev:** Bump esbuild from 0.16.16 to 0.16.17 ([#27](https://github.com/flex-development/errnode/issues/27)) ([9bdcf16](https://github.com/flex-development/errnode/commit/9bdcf1609bbba1b2a3a6ca625c5ba9b41f45848e))
+* **deps-dev:** Bump esbuild from 0.16.17 to 0.17.1 ([#33](https://github.com/flex-development/errnode/issues/33)) ([24c19d9](https://github.com/flex-development/errnode/commit/24c19d9950ba2d9d65c6702a56f00c1105628caf))
+
+
+### :sparkles: Features
+
+* **models:** `ERR_UNKNOWN_BUILTIN_MODULE` ([b16995c](https://github.com/flex-development/errnode/commit/b16995c41487ae0f8b7fbe5d14f91d8ea63eb4f6))
+* **models:** handle trailing separators for package directories ([0a0d256](https://github.com/flex-development/errnode/commit/0a0d25635715699f3c04e622de5ccee02c4045df))
+
 ## [1.3.0](https://github.com/flex-development/errnode/compare/1.2.0...1.3.0) (2023-01-09)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/errnode",
   "description": "Universal API for creating Node.js errors",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "keywords": [
     "error",
     "node",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `1.4.0`
- added `CHANGELOG` entry for `1.4.0`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn typecheck`

```zsh
 RUN  v0.26.3

 ✓ src/enums/__tests__/error-code-system.spec-d.ts (1)
   ✓ unit-d:enums/SystemErrorCode (1)
     ✓ should have members of type Uppercase<string>
 ✓ src/enums/__tests__/error-code.spec-d.ts (1)
   ✓ unit-d:enums/ErrorCode (1)
     ✓ should have members of type Uppercase<string>
 ✓ src/interfaces/__tests__/err-invalid-url.spec-d.ts (3)
   ✓ unit-d:interfaces/ErrInvalidUrl (3)
     ✓ should extend NodeError<TypeError>
     ✓ should match [code: ErrorCode.ERR_INVALID_URL]
     ✓ should match [input: string]
 ✓ src/interfaces/__tests__/errno-exception.spec-d.ts (6)
   ✓ unit-d:interfaces/ErrnoException (6)
     ✓ should extend Error
     ✓ should match [code: SystemErrorCode]
     ✓ should match [errno: number]
     ✓ should match [message: string]
     ✓ should match [path?: string | undefined]
     ✓ should match [syscall: string]
 ✓ src/types/__tests__/fn-message.spec-d.ts (2)
   ✓ unit-d:types/MessageFn (2)
     ✓ should extract parameters from type parameter
     ✓ should return string
 ✓ src/types/__tests__/node-error-constructor.spec-d.ts (5)
   ✓ unit-d:types/NodeErrorConstructor (5)
     ✓ should extract parameters of type any[] if M extends string
     ✓ should extract parameters of type M if M extends any[]
     ✓ should extract parameters of type Parameters<M> if M extends MessageFn
     ✓ should match [prototype: NodeError<T>]
     ✓ should return NodeError<T>
 ✓ src/types/__tests__/node-error.spec-d.ts (2)
   ✓ unit-d:types/NodeError (2)
     ✓ should have type param extend Error type
     ✓ should match [code: ErrorCode]

 Test Files  7 passed (7)
      Tests  20 passed (20)
Type Errors  no errors
   Start at  00:41:10
   Duration  1.99s
```

### `yarn test`

```zsh
 RUN  v0.26.3
      Coverage enabled with c8

 ✓ src/interfaces/__tests__/err-invalid-url.spec-d.ts > unit-d:interfaces/ErrInvalidUrl > should extend NodeError<TypeError>
 ✓ src/interfaces/__tests__/err-invalid-url.spec-d.ts > unit-d:interfaces/ErrInvalidUrl > should match [code: ErrorCode.ERR_INVALID_URL]
 ✓ src/interfaces/__tests__/err-invalid-url.spec-d.ts > unit-d:interfaces/ErrInvalidUrl > should match [input: string]
 ✓ src/interfaces/__tests__/errno-exception.spec-d.ts > unit-d:interfaces/ErrnoException > should extend Error
 ✓ src/internal/__tests__/k-is-node-error.spec.ts > unit:internal/kIsNodeError > should have description "kIsNodeError"
 ✓ src/internal/__tests__/format-list.spec.ts > unit:internal/formatList > should return list string
 ✓ src/internal/__tests__/prepare-stack-trace.spec.ts > unit:internal/prepareStackTrace > should return error with new stack trace
 ✓ src/enums/__tests__/error-code.spec-d.ts > unit-d:enums/ErrorCode > should have members of type Uppercase<string>
 ✓ src/enums/__tests__/error-code-system.spec.ts > unit:enums/SystemErrorCode > should map system error codes to system error codes
 ✓ src/internal/__tests__/format-message.spec.ts > unit:internal/formatMessage > should return formatted messsage if msg is MessageFn
 ✓ src/internal/__tests__/format-message.spec.ts > unit:internal/formatMessage > should return formatted messsage if msg is string
 ✓ src/internal/__tests__/format-message.spec.ts > unit:internal/formatMessage > should return formatted messsage if msg is string
 ✓ src/internal/__tests__/format-message.spec.ts > unit:internal/formatMessage > should throw if args length is invalid
 ✓ src/enums/__tests__/error-code-system.spec-d.ts > unit-d:enums/SystemErrorCode > should have members of type Uppercase<string>
 ✓ src/interfaces/__tests__/errno-exception.spec-d.ts > unit-d:interfaces/ErrnoException > should match [code: SystemErrorCode]
 ✓ src/interfaces/__tests__/errno-exception.spec-d.ts > unit-d:interfaces/ErrnoException > should match [errno: number]
 ✓ src/interfaces/__tests__/errno-exception.spec-d.ts > unit-d:interfaces/ErrnoException > should match [message: string]
 ✓ src/interfaces/__tests__/errno-exception.spec-d.ts > unit-d:interfaces/ErrnoException > should match [path?: string | undefined]
 ✓ src/interfaces/__tests__/errno-exception.spec-d.ts > unit-d:interfaces/ErrnoException > should match [syscall: string]
 ✓ src/internal/__tests__/format-message.spec.ts > unit:internal/formatMessage > should throw if args length is invalid
 ✓ src/models/__tests__/err-ambiguous-argument.spec.ts > unit:models/ERR_AMBIGUOUS_ARGUMENT > should return TypeError instance
 ✓ src/models/__tests__/err-ambiguous-argument.spec.ts > unit:models/ERR_AMBIGUOUS_ARGUMENT > should set error code
 ✓ src/models/__tests__/err-ambiguous-argument.spec.ts > unit:models/ERR_AMBIGUOUS_ARGUMENT > should set error message
 ✓ src/models/__tests__/err-arg-not-iterable.spec.ts > unit:models/ERR_ARG_NOT_ITERABLE > should return TypeError instance
 ✓ src/models/__tests__/err-arg-not-iterable.spec.ts > unit:models/ERR_ARG_NOT_ITERABLE > should set error code
 ✓ src/models/__tests__/err-arg-not-iterable.spec.ts > unit:models/ERR_ARG_NOT_ITERABLE > should set error message
 ✓ src/models/__tests__/err-async-callback.spec.ts > unit:models/ERR_ASYNC_CALLBACK > should return TypeError instance
 ✓ src/models/__tests__/err-async-callback.spec.ts > unit:models/ERR_ASYNC_CALLBACK > should return TypeError instance
 ✓ src/models/__tests__/err-async-callback.spec.ts > unit:models/ERR_ASYNC_CALLBACK > should set error code
 ✓ src/models/__tests__/err-illegal-constructor.spec.ts > unit:models/ERR_ILLEGAL_CONSTRUCTOR > should return TypeError instance
 ✓ src/models/__tests__/err-async-callback.spec.ts > unit:models/ERR_ASYNC_CALLBACK > should set error code
 ✓ src/models/__tests__/err-async-callback.spec.ts > unit:models/ERR_ASYNC_CALLBACK > should set error message
 ✓ src/models/__tests__/err-import-assertion-type-failed.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_FAILED > should return TypeError instance
 ✓ src/models/__tests__/err-import-assertion-type-failed.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_FAILED > should set error code
 ✓ src/models/__tests__/err-import-assertion-type-failed.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_FAILED > should set error message
 ✓ src/models/__tests__/err-illegal-constructor.spec.ts > unit:models/ERR_ILLEGAL_CONSTRUCTOR > should set error code
 ✓ src/models/__tests__/err-illegal-constructor.spec.ts > unit:models/ERR_ILLEGAL_CONSTRUCTOR > should set error message
 ✓ src/models/__tests__/err-invalid-arg-value.spec.ts > unit:models/ERR_INVALID_ARG_VALUE > should return TypeError instance
 ✓ src/models/__tests__/err-invalid-arg-value.spec.ts > unit:models/ERR_INVALID_ARG_VALUE > should set error code
 ✓ src/models/__tests__/err-import-assertion-type-failed.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_FAILED > should set error message
 ✓ src/models/__tests__/err-import-assertion-type-missing.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_MISSING > should return TypeError instance
 ✓ src/models/__tests__/err-import-assertion-type-missing.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_MISSING > should set error code
 ✓ src/models/__tests__/err-incompatible-option-pair.spec.ts > unit:models/ERR_INCOMPATIBLE_OPTION_PAIR > should return TypeError instance
 ✓ src/models/__tests__/err-incompatible-option-pair.spec.ts > unit:models/ERR_INCOMPATIBLE_OPTION_PAIR > should set error code
 ✓ src/models/__tests__/err-invalid-arg-value.spec.ts > unit:models/ERR_INVALID_ARG_VALUE > should set error code
 ✓ src/models/__tests__/err-invalid-arg-value.spec.ts > unit:models/ERR_INVALID_ARG_VALUE > should set error message
 ✓ src/models/__tests__/err-import-assertion-type-missing.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_MISSING > should set error code
 ✓ src/models/__tests__/err-import-assertion-type-missing.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_MISSING > should set error message
 ✓ src/models/__tests__/err-incompatible-option-pair.spec.ts > unit:models/ERR_INCOMPATIBLE_OPTION_PAIR > should set error code
 ✓ src/models/__tests__/err-incompatible-option-pair.spec.ts > unit:models/ERR_INCOMPATIBLE_OPTION_PAIR > should set error message
 ✓ src/models/__tests__/err-invalid-arg-type.spec.ts > unit:models/ERR_INVALID_ARG_TYPE > should return TypeError instance
 ✓ src/models/__tests__/err-invalid-arg-type.spec.ts > unit:models/ERR_INVALID_ARG_TYPE > should set error code
 ✓ src/models/__tests__/err-invalid-arg-type.spec.ts > unit:models/ERR_INVALID_ARG_TYPE > should set error message
 ✓ src/models/__tests__/err-invalid-arg-type.spec.ts > unit:models/ERR_INVALID_ARG_TYPE > should throw if expected is not a string or string[]
 ✓ src/models/__tests__/err-invalid-arg-type.spec.ts > unit:models/ERR_INVALID_ARG_TYPE > should throw if name is not a string
 ✓ src/models/__tests__/err-import-assertion-type-missing.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_MISSING > should set error message
 ✓ src/models/__tests__/err-invalid-arg-value.spec.ts > unit:models/ERR_INVALID_ARG_VALUE > should set error message
 ✓ src/models/__tests__/err-incompatible-option-pair.spec.ts > unit:models/ERR_INCOMPATIBLE_OPTION_PAIR > should set error message
 ✓ src/models/__tests__/err-import-assertion-type-unsupported.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED > should return TypeError instance
 ✓ src/models/__tests__/err-import-assertion-type-unsupported.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED > should set error code
 ✓ src/models/__tests__/err-import-assertion-type-unsupported.spec.ts > unit:models/ERR_IMPORT_ASSERTION_TYPE_UNSUPPORTED > should set error message
 ✓ src/models/__tests__/err-invalid-module-specifier.spec.ts > unit:models/ERR_INVALID_MODULE_SPECIFIER > should return TypeError instance
 ✓ src/models/__tests__/err-invalid-module-specifier.spec.ts > unit:models/ERR_INVALID_MODULE_SPECIFIER > should set error code
 ✓ src/models/__tests__/err-invalid-module-specifier.spec.ts > unit:models/ERR_INVALID_MODULE_SPECIFIER > should set error message
 ✓ src/models/__tests__/err-invalid-package-config.spec.ts > unit:models/ERR_INVALID_PACKAGE_CONFIG > should return Error instance
 ✓ src/models/__tests__/err-invalid-package-config.spec.ts > unit:models/ERR_INVALID_PACKAGE_CONFIG > should set error code
 ✓ src/models/__tests__/err-invalid-package-config.spec.ts > unit:models/ERR_INVALID_PACKAGE_CONFIG > should set error message
 ✓ src/models/__tests__/err-invalid-package-target.spec.ts > unit:models/ERR_INVALID_PACKAGE_TARGET > should return Error instance
 ✓ src/models/__tests__/err-invalid-package-target.spec.ts > unit:models/ERR_INVALID_PACKAGE_TARGET > should set error code
 ✓ src/models/__tests__/err-invalid-package-target.spec.ts > unit:models/ERR_INVALID_PACKAGE_TARGET > should set error message
 ✓ src/models/__tests__/err-invalid-url.spec.ts > unit:models/ERR_INVALID_URL > should return TypeError instance
 ✓ src/models/__tests__/err-invalid-url.spec.ts > unit:models/ERR_INVALID_URL > should set #input
 ✓ src/models/__tests__/err-invalid-url.spec.ts > unit:models/ERR_INVALID_URL > should set error code
 ✓ src/models/__tests__/err-invalid-url.spec.ts > unit:models/ERR_INVALID_URL > should set error message
 ✓ src/models/__tests__/err-module-not-found.spec.ts > unit:models/ERR_MODULE_NOT_FOUND > should return Error instance
 ✓ src/models/__tests__/err-module-not-found.spec.ts > unit:models/ERR_MODULE_NOT_FOUND > should set error code
 ✓ src/models/__tests__/err-module-not-found.spec.ts > unit:models/ERR_MODULE_NOT_FOUND > should set error message
 ✓ src/models/__tests__/err-network-import-disallowed.spec.ts > unit:models/ERR_NETWORK_IMPORT_DISALLOWED > should return Error instance
 ✓ src/models/__tests__/err-network-import-disallowed.spec.ts > unit:models/ERR_NETWORK_IMPORT_DISALLOWED > should set error code
 ✓ src/models/__tests__/err-method-not-implemented.spec.ts > unit:models/ERR_METHOD_NOT_IMPLEMENTED > should return Error instance
 ✓ src/models/__tests__/err-network-import-disallowed.spec.ts > unit:models/ERR_NETWORK_IMPORT_DISALLOWED > should set error code
 ✓ src/models/__tests__/err-network-import-disallowed.spec.ts > unit:models/ERR_NETWORK_IMPORT_DISALLOWED > should set error message
 ✓ src/models/__tests__/err-operation-failed.spec.ts > unit:models/ERR_OPERATION_FAILED > should return Error instance
 ✓ src/models/__tests__/err-module-not-found.spec.ts > unit:models/ERR_MODULE_NOT_FOUND > should set error message
 ✓ src/models/__tests__/err-method-not-implemented.spec.ts > unit:models/ERR_METHOD_NOT_IMPLEMENTED > should set error code
 ✓ src/models/__tests__/err-method-not-implemented.spec.ts > unit:models/ERR_METHOD_NOT_IMPLEMENTED > should set error message
 ✓ src/models/__tests__/err-missing-option.spec.ts > unit:models/ERR_MISSING_OPTION > should return TypeError instance
 ✓ src/models/__tests__/err-missing-option.spec.ts > unit:models/ERR_MISSING_OPTION > should return TypeError instance
 ✓ src/models/__tests__/err-missing-option.spec.ts > unit:models/ERR_MISSING_OPTION > should set error code
 ✓ src/models/__tests__/err-operation-failed.spec.ts > unit:models/ERR_OPERATION_FAILED > should set error code
 ✓ src/models/__tests__/err-operation-failed.spec.ts > unit:models/ERR_OPERATION_FAILED > should set error message
 ✓ src/models/__tests__/err-missing-option.spec.ts > unit:models/ERR_MISSING_OPTION > should set error code
 ✓ src/models/__tests__/err-missing-option.spec.ts > unit:models/ERR_MISSING_OPTION > should set error message
 ✓ src/models/__tests__/err-package-import-not-defined.spec.ts > unit:models/ERR_PACKAGE_IMPORT_NOT_DEFINED > should return TypeError instance
 ✓ src/models/__tests__/err-package-import-not-defined.spec.ts > unit:models/ERR_PACKAGE_IMPORT_NOT_DEFINED > should set error code
 ✓ src/models/__tests__/err-package-import-not-defined.spec.ts > unit:models/ERR_PACKAGE_IMPORT_NOT_DEFINED > should set error message
 ✓ src/models/__tests__/err-package-path-not-exported.spec.ts > unit:models/ERR_PACKAGE_PATH_NOT_EXPORTED > should return Error instance
 ✓ src/models/__tests__/err-package-path-not-exported.spec.ts > unit:models/ERR_PACKAGE_PATH_NOT_EXPORTED > should set error code
 ✓ src/models/__tests__/err-package-path-not-exported.spec.ts > unit:models/ERR_PACKAGE_PATH_NOT_EXPORTED > should set error message
 ✓ src/models/__tests__/err-unhandled-error.spec.ts > unit:models/ERR_UNHANDLED_ERROR > should return Error instance
 ✓ src/models/__tests__/err-unhandled-error.spec.ts > unit:models/ERR_UNHANDLED_ERROR > should set error code
 ✓ src/models/__tests__/err-unhandled-error.spec.ts > unit:models/ERR_UNHANDLED_ERROR > should set error message
 ✓ src/models/__tests__/err-unknown-builtin-module.spec.ts > unit:models/ERR_UNKNOWN_BUILTIN_MODULE > should return Error instance
 ✓ src/models/__tests__/err-unknown-builtin-module.spec.ts > unit:models/ERR_UNKNOWN_BUILTIN_MODULE > should set error code
 ✓ src/models/__tests__/err-unknown-builtin-module.spec.ts > unit:models/ERR_UNKNOWN_BUILTIN_MODULE > should set error message
 ✓ src/models/__tests__/err-unknown-encoding.spec.ts > unit:models/ERR_UNKNOWN_ENCODING > should return TypeError instance
 ✓ src/models/__tests__/err-unknown-encoding.spec.ts > unit:models/ERR_UNKNOWN_ENCODING > should set error code
 ✓ src/models/__tests__/err-unknown-encoding.spec.ts > unit:models/ERR_UNKNOWN_ENCODING > should set error message
 ✓ src/models/__tests__/err-unknown-file-extension.spec.ts > unit:models/ERR_UNKNOWN_FILE_EXTENSION > should return TypeError instance
 ✓ src/models/__tests__/err-unknown-file-extension.spec.ts > unit:models/ERR_UNKNOWN_FILE_EXTENSION > should set error code
 ✓ src/models/__tests__/err-unknown-file-extension.spec.ts > unit:models/ERR_UNKNOWN_FILE_EXTENSION > should set error message
 ✓ src/models/__tests__/err-unknown-file-extension.spec.ts > unit:models/ERR_UNKNOWN_FILE_EXTENSION > should set error message
 ✓ src/models/__tests__/err-unknown-module-format.spec.ts > unit:models/ERR_UNKNOWN_MODULE_FORMAT > should return RangeError instance
 ✓ src/models/__tests__/err-unknown-module-format.spec.ts > unit:models/ERR_UNKNOWN_MODULE_FORMAT > should set error code
 ✓ src/models/__tests__/err-unknown-module-format.spec.ts > unit:models/ERR_UNKNOWN_MODULE_FORMAT > should set error message
 ✓ src/models/__tests__/err-unsupported-dir-import.spec.ts > unit:models/ERR_UNSUPPORTED_DIR_IMPORT > should return Error instance
 ✓ src/models/__tests__/err-unsupported-dir-import.spec.ts > unit:models/ERR_UNSUPPORTED_DIR_IMPORT > should set error code
 ✓ src/models/__tests__/err-unsupported-dir-import.spec.ts > unit:models/ERR_UNSUPPORTED_DIR_IMPORT > should set error message
 ✓ src/types/__tests__/node-error-constructor.spec-d.ts > unit-d:types/NodeErrorConstructor > should extract parameters of type any[] if M extends string
 ✓ src/types/__tests__/fn-message.spec-d.ts > unit-d:types/MessageFn > should extract parameters from type parameter
 ✓ src/types/__tests__/fn-message.spec-d.ts > unit-d:types/MessageFn > should return string
 ✓ src/types/__tests__/node-error-constructor.spec-d.ts > unit-d:types/NodeErrorConstructor > should extract parameters of type any[] if M extends string
 ✓ src/types/__tests__/node-error-constructor.spec-d.ts > unit-d:types/NodeErrorConstructor > should extract parameters of type M if M extends any[]
 ✓ src/types/__tests__/node-error-constructor.spec-d.ts > unit-d:types/NodeErrorConstructor > should extract parameters of type Parameters<M> if M extends MessageFn
 ✓ src/types/__tests__/node-error-constructor.spec-d.ts > unit-d:types/NodeErrorConstructor > should match [prototype: NodeError<T>]
 ✓ src/types/__tests__/node-error-constructor.spec-d.ts > unit-d:types/NodeErrorConstructor > should return NodeError<T>
 ✓ src/models/__tests__/err-unsupported-esm-url-scheme.spec.ts > unit:models/ERR_UNSUPPORTED_ESM_URL_SCHEME > should return Error instance
 ✓ src/models/__tests__/err-unsupported-esm-url-scheme.spec.ts > unit:models/ERR_UNSUPPORTED_ESM_URL_SCHEME > should set error code
 ✓ src/models/__tests__/err-unsupported-esm-url-scheme.spec.ts > unit:models/ERR_UNSUPPORTED_ESM_URL_SCHEME > should set error message
 ✓ src/types/__tests__/node-error.spec-d.ts > unit-d:types/NodeError > should have type param extend Error type
 ✓ src/types/__tests__/node-error.spec-d.ts > unit-d:types/NodeError > should match [code: ErrorCode]
 ✓ src/utils/__tests__/create-node-error.spec.ts > unit:utils/createNodeError > should return NodeErrorConstructor
 ✓ src/utils/__tests__/create-node-error.spec.ts > unit:utils/createNodeError > NodeError > should return NodeError instance
 ✓ src/utils/__tests__/determine-specific-type.spec.ts > unit:utils/determineSpecificType > should detect bigint
 ✓ src/utils/__tests__/determine-specific-type.spec.ts > unit:utils/determineSpecificType > should detect boolean
 ✓ src/utils/__tests__/determine-specific-type.spec.ts > unit:utils/determineSpecificType > should detect function
 ✓ src/utils/__tests__/determine-specific-type.spec.ts > unit:utils/determineSpecificType > should detect instance object
 ✓ src/utils/__tests__/determine-specific-type.spec.ts > unit:utils/determineSpecificType > should detect null
 ✓ src/utils/__tests__/determine-specific-type.spec.ts > unit:utils/determineSpecificType > should detect number
 ✓ src/utils/__tests__/determine-specific-type.spec.ts > unit:utils/determineSpecificType > should detect string
 ✓ src/utils/__tests__/determine-specific-type.spec.ts > unit:utils/determineSpecificType > should detect symbol
 ✓ src/utils/__tests__/determine-specific-type.spec.ts > unit:utils/determineSpecificType > should detect undefined

 Test Files  42 passed (42)
      Tests  125 passed (125)
   Start at  00:41:26
   Duration  11.20s (transform 2.99s, setup 25.03s, collect 8.23s, tests 2.78s)

 % Coverage report from c8
-------------------------------------------|---------|----------|---------|---------|-------------------
File                                       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------------------------------|---------|----------|---------|---------|-------------------
All files                                  |     100 |      100 |     100 |     100 |                   
 enums                                     |     100 |      100 |     100 |     100 |                   
  error-code-system.ts                     |     100 |      100 |     100 |     100 |                   
  error-code.ts                            |     100 |      100 |     100 |     100 |                   
 internal                                  |     100 |      100 |     100 |     100 |                   
  format-list.ts                           |     100 |      100 |     100 |     100 |                   
  format-message.ts                        |     100 |      100 |     100 |     100 |                   
  k-is-node-error.ts                       |     100 |      100 |     100 |     100 |                   
  prepare-stack-trace.ts                   |     100 |      100 |     100 |     100 |                   
 models                                    |     100 |      100 |     100 |     100 |                   
  err-ambiguous-argument.ts                |     100 |      100 |     100 |     100 |                   
  err-arg-not-iterable.ts                  |     100 |      100 |     100 |     100 |                   
  err-async-callback.ts                    |     100 |      100 |     100 |     100 |                   
  err-illegal-constructor.ts               |     100 |      100 |     100 |     100 |                   
  err-import-assertion-type-failed.ts      |     100 |      100 |     100 |     100 |                   
  err-import-assertion-type-missing.ts     |     100 |      100 |     100 |     100 |                   
  err-import-assertion-type-unsupported.ts |     100 |      100 |     100 |     100 |                   
  err-incompatible-option-pair.ts          |     100 |      100 |     100 |     100 |                   
  err-invalid-arg-type.ts                  |     100 |      100 |     100 |     100 |                   
  err-invalid-arg-value.ts                 |     100 |      100 |     100 |     100 |                   
  err-invalid-module-specifier.ts          |     100 |      100 |     100 |     100 |                   
  err-invalid-package-config.ts            |     100 |      100 |     100 |     100 |                   
  err-invalid-package-target.ts            |     100 |      100 |     100 |     100 |                   
  err-invalid-url.ts                       |     100 |      100 |     100 |     100 |                   
  err-method-not-implemented.ts            |     100 |      100 |     100 |     100 |                   
  err-missing-option.ts                    |     100 |      100 |     100 |     100 |                   
  err-module-not-found.ts                  |     100 |      100 |     100 |     100 |                   
  err-network-import-disallowed.ts         |     100 |      100 |     100 |     100 |                   
  err-operation-failed.ts                  |     100 |      100 |     100 |     100 |                   
  err-package-import-not-defined.ts        |     100 |      100 |     100 |     100 |                   
  err-package-path-not-exported.ts         |     100 |      100 |     100 |     100 |                   
  err-unhandled-error.ts                   |     100 |      100 |     100 |     100 |                   
  err-unknown-builtin-module.ts            |     100 |      100 |     100 |     100 |                   
  err-unknown-encoding.ts                  |     100 |      100 |     100 |     100 |                   
  err-unknown-file-extension.ts            |     100 |      100 |     100 |     100 |                   
  err-unknown-module-format.ts             |     100 |      100 |     100 |     100 |                   
  err-unsupported-dir-import.ts            |     100 |      100 |     100 |     100 |                   
  err-unsupported-esm-url-scheme.ts        |     100 |      100 |     100 |     100 |                   
 utils                                     |     100 |      100 |     100 |     100 |                   
  create-node-error.ts                     |     100 |      100 |     100 |     100 |                   
  determine-specific-type.ts               |     100 |      100 |     100 |     100 |                   
-------------------------------------------|---------|----------|---------|---------|-------------------
```

### `yarn pack -o %s-%v.tgz`

```zsh
➤ YN0036: Calling the "prepack" lifecycle script
➤ YN0000: @flex-development/errnode@workspace:. STDOUT ℹ Building @flex-development/errnode
➤ YN0000: @flex-development/errnode@workspace:. STDOUT ✔ Build succeeded for @flex-development/errnode
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   dist (total size: 146 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/index.mjs.map (152 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/index.mjs (223 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/index.d.mts (223 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/enums/error-code-system.mjs.map (2.47 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/enums/error-code-system.mjs (4.83 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/enums/error-code-system.d.mts (3.03 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/enums/error-code.mjs.map (8.64 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/enums/error-code.mjs (26.3 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/enums/error-code.d.mts (22.1 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/enums/index.mjs.map (153 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/enums/index.mjs (213 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/enums/index.d.mts (181 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/interfaces/err-invalid-url.mjs.map (69 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/interfaces/err-invalid-url.mjs (45 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/interfaces/err-invalid-url.d.mts (626 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/interfaces/errno-exception.mjs.map (69 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/interfaces/errno-exception.mjs (45 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/interfaces/errno-exception.d.mts (1.39 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/interfaces/index.mjs.map (69 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/interfaces/index.mjs (35 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/interfaces/index.d.mts (207 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/format-list.mjs.map (281 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/format-list.mjs (301 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/format-list.d.mts (758 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/format-message.mjs.map (620 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/format-message.mjs (925 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/format-message.d.mts (1.1 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/k-is-node-error.mjs.map (151 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/k-is-node-error.mjs (183 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/k-is-node-error.d.mts (215 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/prepare-stack-trace.mjs.map (352 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/prepare-stack-trace.mjs (451 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/internal/prepare-stack-trace.d.mts (515 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/fn-message.mjs.map (69 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/fn-message.mjs (40 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/fn-message.d.mts (357 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/index.mjs.map (69 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/index.mjs (35 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/index.d.mts (270 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/node-error-constructor.mjs.map (69 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/node-error-constructor.mjs (52 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/node-error-constructor.d.mts (1.31 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/node-error.mjs.map (69 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/node-error.mjs (40 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/types/node-error.d.mts (352 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-ambiguous-argument.mjs.map (222 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-ambiguous-argument.mjs (394 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-ambiguous-argument.d.mts (808 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-arg-not-iterable.mjs.map (219 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-arg-not-iterable.mjs (367 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-arg-not-iterable.d.mts (742 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-async-callback.mjs.map (217 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-async-callback.mjs (357 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-async-callback.d.mts (711 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-illegal-constructor.mjs.map (222 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-illegal-constructor.mjs (385 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-illegal-constructor.d.mts (650 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-import-assertion-type-failed.mjs.map (232 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-import-assertion-type-failed.mjs (451 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-import-assertion-type-failed.d.mts (862 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-import-assertion-type-missing.mjs.map (233 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-import-assertion-type-missing.mjs (476 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-import-assertion-type-missing.d.mts (869 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-import-assertion-type-unsupported.mjs.map (236 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-import-assertion-type-unsupported.mjs (491 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-import-assertion-type-unsupported.d.mts (797 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-incompatible-option-pair.mjs.map (228 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-incompatible-option-pair.mjs (454 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-incompatible-option-pair.d.mts (848 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-arg-type.mjs.map (1.59 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-arg-type.mjs (2.73 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-arg-type.d.mts (907 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-arg-value.mjs.map (525 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-arg-value.mjs (1.13 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-arg-value.d.mts (876 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-module-specifier.mjs.map (397 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-module-specifier.mjs (958 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-module-specifier.d.mts (936 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-package-config.mjs.map (410 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-package-config.mjs (1.02 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-package-config.d.mts (999 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-package-target.mjs.map (632 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-package-target.mjs (1.52 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-package-target.d.mts (1.22 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-url.mjs.map (318 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-url.mjs (644 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-invalid-url.d.mts (990 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-method-not-implemented.mjs.map (225 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-method-not-implemented.mjs (412 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-method-not-implemented.d.mts (666 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-missing-option.mjs.map (209 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-missing-option.mjs (342 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-missing-option.d.mts (693 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-module-not-found.mjs.map (335 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-module-not-found.mjs (789 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-module-not-found.d.mts (897 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-network-import-disallowed.mjs.map (229 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-network-import-disallowed.mjs (439 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-network-import-disallowed.d.mts (886 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-operation-failed.mjs.map (211 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-operation-failed.mjs (356 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-operation-failed.d.mts (702 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-package-import-not-defined.mjs.map (416 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-package-import-not-defined.mjs (1.07 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-package-import-not-defined.d.mts (1.02 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-package-path-not-exported.mjs.map (430 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-package-path-not-exported.mjs (1.08 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-package-path-not-exported.d.mts (958 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unhandled-error.mjs.map (342 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unhandled-error.mjs (682 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unhandled-error.d.mts (619 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-builtin-module.mjs.map (226 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-builtin-module.mjs (407 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-builtin-module.d.mts (736 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-encoding.mjs.map (219 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-encoding.mjs (368 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-encoding.d.mts (691 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-file-extension.mjs.map (379 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-file-extension.mjs (922 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-file-extension.d.mts (899 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-module-format.mjs.map (225 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-module-format.mjs (415 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unknown-module-format.d.mts (805 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unsupported-dir-import.mjs.map (285 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unsupported-dir-import.mjs (570 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unsupported-dir-import.d.mts (742 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unsupported-esm-url-scheme.mjs.map (478 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unsupported-esm-url-scheme.mjs (1.22 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/err-unsupported-esm-url-scheme.d.mts (1 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/index.mjs.map (804 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/index.mjs (3.1 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/models/index.d.mts (2.47 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/utils/create-node-error.mjs.map (831 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/utils/create-node-error.mjs (1.39 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/utils/create-node-error.d.mts (1.34 kB)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/utils/determine-specific-type.mjs.map (595 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/utils/determine-specific-type.mjs (935 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/utils/determine-specific-type.d.mts (456 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/utils/index.mjs.map (153 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/utils/index.mjs (238 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT   └─ dist/utils/index.d.mts (210 B)
➤ YN0000: @flex-development/errnode@workspace:. STDOUT Σ Total build size: 146 kB
➤ YN0000: CHANGELOG.md
➤ YN0000: LICENSE.md
➤ YN0000: README.md
➤ YN0000: changelog.config.cts
➤ YN0000: dist/enums/error-code-system.d.mts
➤ YN0000: dist/enums/error-code-system.mjs
➤ YN0000: dist/enums/error-code-system.mjs.map
➤ YN0000: dist/enums/error-code.d.mts
➤ YN0000: dist/enums/error-code.mjs
➤ YN0000: dist/enums/error-code.mjs.map
➤ YN0000: dist/enums/index.d.mts
➤ YN0000: dist/enums/index.mjs
➤ YN0000: dist/enums/index.mjs.map
➤ YN0000: dist/index.d.mts
➤ YN0000: dist/index.mjs
➤ YN0000: dist/index.mjs.map
➤ YN0000: dist/interfaces/err-invalid-url.d.mts
➤ YN0000: dist/interfaces/err-invalid-url.mjs
➤ YN0000: dist/interfaces/err-invalid-url.mjs.map
➤ YN0000: dist/interfaces/errno-exception.d.mts
➤ YN0000: dist/interfaces/errno-exception.mjs
➤ YN0000: dist/interfaces/errno-exception.mjs.map
➤ YN0000: dist/interfaces/index.d.mts
➤ YN0000: dist/interfaces/index.mjs
➤ YN0000: dist/interfaces/index.mjs.map
➤ YN0000: dist/internal/format-list.d.mts
➤ YN0000: dist/internal/format-list.mjs
➤ YN0000: dist/internal/format-list.mjs.map
➤ YN0000: dist/internal/format-message.d.mts
➤ YN0000: dist/internal/format-message.mjs
➤ YN0000: dist/internal/format-message.mjs.map
➤ YN0000: dist/internal/k-is-node-error.d.mts
➤ YN0000: dist/internal/k-is-node-error.mjs
➤ YN0000: dist/internal/k-is-node-error.mjs.map
➤ YN0000: dist/internal/prepare-stack-trace.d.mts
➤ YN0000: dist/internal/prepare-stack-trace.mjs
➤ YN0000: dist/internal/prepare-stack-trace.mjs.map
➤ YN0000: dist/models/err-ambiguous-argument.d.mts
➤ YN0000: dist/models/err-ambiguous-argument.mjs
➤ YN0000: dist/models/err-ambiguous-argument.mjs.map
➤ YN0000: dist/models/err-arg-not-iterable.d.mts
➤ YN0000: dist/models/err-arg-not-iterable.mjs
➤ YN0000: dist/models/err-arg-not-iterable.mjs.map
➤ YN0000: dist/models/err-async-callback.d.mts
➤ YN0000: dist/models/err-async-callback.mjs
➤ YN0000: dist/models/err-async-callback.mjs.map
➤ YN0000: dist/models/err-illegal-constructor.d.mts
➤ YN0000: dist/models/err-illegal-constructor.mjs
➤ YN0000: dist/models/err-illegal-constructor.mjs.map
➤ YN0000: dist/models/err-import-assertion-type-failed.d.mts
➤ YN0000: dist/models/err-import-assertion-type-failed.mjs
➤ YN0000: dist/models/err-import-assertion-type-failed.mjs.map
➤ YN0000: dist/models/err-import-assertion-type-missing.d.mts
➤ YN0000: dist/models/err-import-assertion-type-missing.mjs
➤ YN0000: dist/models/err-import-assertion-type-missing.mjs.map
➤ YN0000: dist/models/err-import-assertion-type-unsupported.d.mts
➤ YN0000: dist/models/err-import-assertion-type-unsupported.mjs
➤ YN0000: dist/models/err-import-assertion-type-unsupported.mjs.map
➤ YN0000: dist/models/err-incompatible-option-pair.d.mts
➤ YN0000: dist/models/err-incompatible-option-pair.mjs
➤ YN0000: dist/models/err-incompatible-option-pair.mjs.map
➤ YN0000: dist/models/err-invalid-arg-type.d.mts
➤ YN0000: dist/models/err-invalid-arg-type.mjs
➤ YN0000: dist/models/err-invalid-arg-type.mjs.map
➤ YN0000: dist/models/err-invalid-arg-value.d.mts
➤ YN0000: dist/models/err-invalid-arg-value.mjs
➤ YN0000: dist/models/err-invalid-arg-value.mjs.map
➤ YN0000: dist/models/err-invalid-module-specifier.d.mts
➤ YN0000: dist/models/err-invalid-module-specifier.mjs
➤ YN0000: dist/models/err-invalid-module-specifier.mjs.map
➤ YN0000: dist/models/err-invalid-package-config.d.mts
➤ YN0000: dist/models/err-invalid-package-config.mjs
➤ YN0000: dist/models/err-invalid-package-config.mjs.map
➤ YN0000: dist/models/err-invalid-package-target.d.mts
➤ YN0000: dist/models/err-invalid-package-target.mjs
➤ YN0000: dist/models/err-invalid-package-target.mjs.map
➤ YN0000: dist/models/err-invalid-url.d.mts
➤ YN0000: dist/models/err-invalid-url.mjs
➤ YN0000: dist/models/err-invalid-url.mjs.map
➤ YN0000: dist/models/err-method-not-implemented.d.mts
➤ YN0000: dist/models/err-method-not-implemented.mjs
➤ YN0000: dist/models/err-method-not-implemented.mjs.map
➤ YN0000: dist/models/err-missing-option.d.mts
➤ YN0000: dist/models/err-missing-option.mjs
➤ YN0000: dist/models/err-missing-option.mjs.map
➤ YN0000: dist/models/err-module-not-found.d.mts
➤ YN0000: dist/models/err-module-not-found.mjs
➤ YN0000: dist/models/err-module-not-found.mjs.map
➤ YN0000: dist/models/err-network-import-disallowed.d.mts
➤ YN0000: dist/models/err-network-import-disallowed.mjs
➤ YN0000: dist/models/err-network-import-disallowed.mjs.map
➤ YN0000: dist/models/err-operation-failed.d.mts
➤ YN0000: dist/models/err-operation-failed.mjs
➤ YN0000: dist/models/err-operation-failed.mjs.map
➤ YN0000: dist/models/err-package-import-not-defined.d.mts
➤ YN0000: dist/models/err-package-import-not-defined.mjs
➤ YN0000: dist/models/err-package-import-not-defined.mjs.map
➤ YN0000: dist/models/err-package-path-not-exported.d.mts
➤ YN0000: dist/models/err-package-path-not-exported.mjs
➤ YN0000: dist/models/err-package-path-not-exported.mjs.map
➤ YN0000: dist/models/err-unhandled-error.d.mts
➤ YN0000: dist/models/err-unhandled-error.mjs
➤ YN0000: dist/models/err-unhandled-error.mjs.map
➤ YN0000: dist/models/err-unknown-builtin-module.d.mts
➤ YN0000: dist/models/err-unknown-builtin-module.mjs
➤ YN0000: dist/models/err-unknown-builtin-module.mjs.map
➤ YN0000: dist/models/err-unknown-encoding.d.mts
➤ YN0000: dist/models/err-unknown-encoding.mjs
➤ YN0000: dist/models/err-unknown-encoding.mjs.map
➤ YN0000: dist/models/err-unknown-file-extension.d.mts
➤ YN0000: dist/models/err-unknown-file-extension.mjs
➤ YN0000: dist/models/err-unknown-file-extension.mjs.map
➤ YN0000: dist/models/err-unknown-module-format.d.mts
➤ YN0000: dist/models/err-unknown-module-format.mjs
➤ YN0000: dist/models/err-unknown-module-format.mjs.map
➤ YN0000: dist/models/err-unsupported-dir-import.d.mts
➤ YN0000: dist/models/err-unsupported-dir-import.mjs
➤ YN0000: dist/models/err-unsupported-dir-import.mjs.map
➤ YN0000: dist/models/err-unsupported-esm-url-scheme.d.mts
➤ YN0000: dist/models/err-unsupported-esm-url-scheme.mjs
➤ YN0000: dist/models/err-unsupported-esm-url-scheme.mjs.map
➤ YN0000: dist/models/index.d.mts
➤ YN0000: dist/models/index.mjs
➤ YN0000: dist/models/index.mjs.map
➤ YN0000: dist/types/fn-message.d.mts
➤ YN0000: dist/types/fn-message.mjs
➤ YN0000: dist/types/fn-message.mjs.map
➤ YN0000: dist/types/index.d.mts
➤ YN0000: dist/types/index.mjs
➤ YN0000: dist/types/index.mjs.map
➤ YN0000: dist/types/node-error-constructor.d.mts
➤ YN0000: dist/types/node-error-constructor.mjs
➤ YN0000: dist/types/node-error-constructor.mjs.map
➤ YN0000: dist/types/node-error.d.mts
➤ YN0000: dist/types/node-error.mjs
➤ YN0000: dist/types/node-error.mjs.map
➤ YN0000: dist/utils/create-node-error.d.mts
➤ YN0000: dist/utils/create-node-error.mjs
➤ YN0000: dist/utils/create-node-error.mjs.map
➤ YN0000: dist/utils/determine-specific-type.d.mts
➤ YN0000: dist/utils/determine-specific-type.mjs
➤ YN0000: dist/utils/determine-specific-type.mjs.map
➤ YN0000: dist/utils/index.d.mts
➤ YN0000: dist/utils/index.mjs
➤ YN0000: dist/utils/index.mjs.map
➤ YN0000: package.json
➤ YN0000: src/enums/error-code-system.ts
➤ YN0000: src/enums/error-code.ts
➤ YN0000: src/enums/index.ts
➤ YN0000: src/index.ts
➤ YN0000: src/interfaces/err-invalid-url.ts
➤ YN0000: src/interfaces/errno-exception.ts
➤ YN0000: src/interfaces/index.ts
➤ YN0000: src/internal/format-list.ts
➤ YN0000: src/internal/format-message.ts
➤ YN0000: src/internal/k-is-node-error.ts
➤ YN0000: src/internal/prepare-stack-trace.ts
➤ YN0000: src/models/err-ambiguous-argument.ts
➤ YN0000: src/models/err-arg-not-iterable.ts
➤ YN0000: src/models/err-async-callback.ts
➤ YN0000: src/models/err-illegal-constructor.ts
➤ YN0000: src/models/err-import-assertion-type-failed.ts
➤ YN0000: src/models/err-import-assertion-type-missing.ts
➤ YN0000: src/models/err-import-assertion-type-unsupported.ts
➤ YN0000: src/models/err-incompatible-option-pair.ts
➤ YN0000: src/models/err-invalid-arg-type.ts
➤ YN0000: src/models/err-invalid-arg-value.ts
➤ YN0000: src/models/err-invalid-module-specifier.ts
➤ YN0000: src/models/err-invalid-package-config.ts
➤ YN0000: src/models/err-invalid-package-target.ts
➤ YN0000: src/models/err-invalid-url.ts
➤ YN0000: src/models/err-method-not-implemented.ts
➤ YN0000: src/models/err-missing-option.ts
➤ YN0000: src/models/err-module-not-found.ts
➤ YN0000: src/models/err-network-import-disallowed.ts
➤ YN0000: src/models/err-operation-failed.ts
➤ YN0000: src/models/err-package-import-not-defined.ts
➤ YN0000: src/models/err-package-path-not-exported.ts
➤ YN0000: src/models/err-unhandled-error.ts
➤ YN0000: src/models/err-unknown-builtin-module.ts
➤ YN0000: src/models/err-unknown-encoding.ts
➤ YN0000: src/models/err-unknown-file-extension.ts
➤ YN0000: src/models/err-unknown-module-format.ts
➤ YN0000: src/models/err-unsupported-dir-import.ts
➤ YN0000: src/models/err-unsupported-esm-url-scheme.ts
➤ YN0000: src/models/index.ts
➤ YN0000: src/types/fn-message.ts
➤ YN0000: src/types/index.ts
➤ YN0000: src/types/node-error-constructor.ts
➤ YN0000: src/types/node-error.ts
➤ YN0000: src/utils/create-node-error.ts
➤ YN0000: src/utils/determine-specific-type.ts
➤ YN0000: src/utils/index.ts
➤ YN0036: Calling the "postpack" lifecycle script
➤ YN0000: Package archive generated in ./@flex-development-errnode-1.4.0.tgz
➤ YN0000: Done in 5s 745ms
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/errnode/blob/main/CONTRIBUTING.md#pull-request-titles
